### PR TITLE
include plugin build dirs, exclude assets and node_modules.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,12 @@ recursive-include kolibri/utils *
 recursive-include kolibri/tasks *
 recursive-exclude kolibri/* *pyc
 recursive-include kolibri/*/static *.*
-recursive-include kolibri/core/build/ *
+recursive-include kolibri/*/build/ *.json
+recursive-include kolibri/plugins/*/build *.json
+
+recursive-exclude kolibri/core/assets *
+recursive-exclude kolibri/plugins/*/assets *
+recursive-exclude kolibri/plugins/*/node_modules *
+
 recursive-exclude kolibri/dist *pyc
 prune kolibri/dist/*/__pycache___


### PR DESCRIPTION
Smaller wheels and sdists!
