### PR TITLE
test overriding

### DIFF
--- a/frontend_build/src/apiSpecExportTools.js
+++ b/frontend_build/src/apiSpecExportTools.js
@@ -11,10 +11,15 @@ var path = require("path");
 var specFilePath = path.resolve(path.join(__dirname, '../../kolibri/core/assets/src/core-app/apiSpec.js'))
 
 function specModule(filePath) {
+  var rootPath = path.dirname(filePath);
+  function newPath(match, p1) {
+    return "'" + path.join(rootPath, p1) + "'";
+  }
+
   // Read the spec file and do a regex replace to change all instances of 'require('...')'
   // to just be the string of the require path.
   // Our strict linting rules should ensure that this regex suffices.
-  var apiSpecFile = fs.readFileSync(filePath, 'utf-8').replace(/require\(('\S+')\)/g, '$1');
+  var apiSpecFile = fs.readFileSync(filePath, 'utf-8').replace(/require\('(\S+)'\)/g, newPath);
 
   // Invoke the module constructor to compile a module from this altered representation.
   var Module = module.constructor;

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -94,7 +94,7 @@ var config = {
   ],
   resolve: {
     alias: aliases,
-    extensions: ["", ".vue", ".js"],
+    extensions: ["", ".styl", ".vue", ".js"],
   },
   eslint: {
     failOnError: true

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -107,6 +107,9 @@ module.exports = {
         sessionNavWidget: {
           module: require('../vue/session-nav-widget'),
         },
+        test: {
+          module: require('../vue/core-test'),
+        },
       },
       router: {
         module: require('../router'),

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -117,10 +117,10 @@ module.exports = {
     },
     styles: {
       navBarItem: {
-        module: require('../vue/nav-bar/nav-bar-item.styl'),
+        module: require('../vue/nav-bar/nav-bar-item'),
       },
       coreTheme: {
-        module: require('../styles/core-theme.styl'),
+        module: require('../styles/core-theme'),
       },
     },
   },

--- a/kolibri/core/assets/src/vue/core-base.vue
+++ b/kolibri/core/assets/src/vue/core-base.vue
@@ -1,14 +1,7 @@
 <template>
 
   <div>
-    <nav-bar :topLevelPageName="topLevelPageName"/>
-    <loading-spinner v-if="loading" class="loading-spinner-fixed"/>
-    <div class="main-wrapper" v-scroll="onScroll" v-if="!loading">
-      <error-box v-if="error"/>
-      <slot name="above"/>
-      <slot name="content"/>
-      <slot name="below"/>
-    </div>
+    <test />
   </div>
 
 </template>
@@ -43,6 +36,7 @@
       'nav-bar': require('./nav-bar'),
       'error-box': require('./error-box'),
       'loading-spinner': require('kolibri.coreVue.components.loadingSpinner'),
+      'test': require('kolibri.coreVue.components.test'),
     },
     vuex: {
       actions: {

--- a/kolibri/core/assets/src/vue/core-test.vue
+++ b/kolibri/core/assets/src/vue/core-test.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    I'm a core component.
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {};
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  div
+    background-color: yellow
+
+</style>

--- a/kolibri/plugins/audio_mp3_render/assets/src/coreAPI.js
+++ b/kolibri/plugins/audio_mp3_render/assets/src/coreAPI.js
@@ -1,0 +1,9 @@
+module.exports = {
+  coreVue: {
+    components: {
+      test: {
+        module: require('./vue/new-test'),
+      },
+    },
+  },
+};

--- a/kolibri/plugins/audio_mp3_render/assets/src/vue/new-test.vue
+++ b/kolibri/plugins/audio_mp3_render/assets/src/vue/new-test.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div>
+    I'm in a plugin!
+  </div>
+
+</template>
+
+
+<script>
+
+  module.exports = {};
+
+</script>
+
+
+<style lang="stylus" scoped>
+
+  div
+    background-color: blue
+
+</style>

--- a/kolibri/plugins/audio_mp3_render/webpack.config.js
+++ b/kolibri/plugins/audio_mp3_render/webpack.config.js
@@ -4,6 +4,7 @@
  */
 
 module.exports = {
+  coreAPISpec: './assets/src/coreAPI.js',
   module: {
     loaders: [
       // Allows <video> and <audio> HTML5 tags work on all major browsers.


### PR DESCRIPTION
Experimenting with module overriding.

It looks like perhaps the `specModule` function in _apiSpecExportTools.js_ is not properly setting the module base path. Running the code in this PR gives this error on build:

```
Child default_frontend:
    Hash: 55e1e06b26afda1c3eb8
    Version: webpack 1.13.1
    Time: 23203ms
                                                   Asset     Size  Chunks             Chunk Names
    loading-spinner.gif?e850c29286b4eb51d1e5e00738b3fc04  98.8 kB          [emitted]  
       kolibri-logo.svg?e9efee91576fa4fabe5eb6a15b52ddd9  15.7 kB          [emitted]  
                               default_frontend-0.2c1.js  5.27 MB       0  [emitted]  default_frontend
                                            1.1-0.2c1.js   478 kB       1  [emitted]  
    
    ERROR in ./~/buble-loader!./~/vue-loader/lib/selector.js?type=script&index=0!./kolibri/core/assets/src/vue/core-base.vue
    Module not found: Error: Cannot resolve 'file' or 'directory' /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test in /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/vue
    resolve file
      /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test.vue doesn't exist
      /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test.js doesn't exist
      /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test doesn't exist
    resolve directory
      /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test doesn't exist (directory default file)
      /Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test/package.json doesn't exist (directory description file)
    [/Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test.vue]
    [/Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test.js]
    [/Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test]
     @ ./~/buble-loader!./~/vue-loader/lib/selector.js?type=script&index=0!./kolibri/core/assets/src/vue/core-base.vue 39:12-54
```


Note in particular that it's looking for

```
/Users/d/Projects/learning_equality/repos/kolibri/kolibri/core/assets/src/core-app/vue/new-test
```

The actual file path is 

```
/Users/d/Projects/learning_equality/repos/kolibri/kolibri/plugins/audio_mp3_render/assets/src/vue/new-test
```
