### PR TITLE
Branding fixes

### DIFF
--- a/frontend_build/src/apiSpecExportTools.js
+++ b/frontend_build/src/apiSpecExportTools.js
@@ -11,10 +11,15 @@ var path = require("path");
 var specFilePath = path.resolve(path.join(__dirname, '../../kolibri/core/assets/src/core-app/apiSpec.js'))
 
 function specModule(filePath) {
+  var rootPath = path.dirname(filePath);
+  function newPath(match, p1) {
+    return "'" + path.join(rootPath, p1) + "'";
+  }
+
   // Read the spec file and do a regex replace to change all instances of 'require('...')'
   // to just be the string of the require path.
   // Our strict linting rules should ensure that this regex suffices.
-  var apiSpecFile = fs.readFileSync(filePath, 'utf-8').replace(/require\(('\S+')\)/g, '$1');
+  var apiSpecFile = fs.readFileSync(filePath, 'utf-8').replace(/require\('(\S+)'\)/g, newPath);
 
   // Invoke the module constructor to compile a module from this altered representation.
   var Module = module.constructor;

--- a/frontend_build/src/webpack.config.base.js
+++ b/frontend_build/src/webpack.config.base.js
@@ -94,7 +94,7 @@ var config = {
   ],
   resolve: {
     alias: aliases,
-    extensions: ["", ".vue", ".js"],
+    extensions: ["", ".styl", ".vue", ".js"],
   },
   eslint: {
     failOnError: true

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -114,10 +114,10 @@ module.exports = {
     },
     styles: {
       navBarItem: {
-        module: require('../vue/nav-bar/nav-bar-item.styl'),
+        module: require('../vue/nav-bar/nav-bar-item'),
       },
       coreTheme: {
-        module: require('../styles/core-theme.styl'),
+        module: require('../styles/core-theme'),
       },
     },
   },


### PR DESCRIPTION

These changes address some issues I was having, demo'd here: https://github.com/rtibbles/kolibri/pull/6

In particular, modules are now compiled with absolute paths so that local relative references are resolved.

Also found an issue where `require` statements with dots in the names were skipped (e.g. if a file is named with .styl or .vue). The logic responsible is here: https://github.com/rtibbles/kolibri/blob/brand_my_build/frontend_build/src/apiSpecExportTools.js#L78

I briefly looked at fixing the code but instead just took out the dots. I'll make an issue for this.