### PR TITLE
Add flag to AssesmentMetaDataSerializer

### DIFF
--- a/kolibri/content/serializers.py
+++ b/kolibri/content/serializers.py
@@ -47,7 +47,7 @@ class ContentNodeSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
     progress_fraction = serializers.SerializerMethodField()
     next_content = serializers.SerializerMethodField()
-    assessmentmetadata = AssessmentMetaDataSerializer(read_only=True, allow_null=True)
+    assessmentmetadata = AssessmentMetaDataSerializer(read_only=True, allow_null=True, many=True)
 
     def __init__(self, *args, **kwargs):
         # Instantiate the superclass normally


### PR DESCRIPTION
## Summary

* Add flag to AssesmentMetaDataSerializer
* Fixes the following error. 
```
Got AttributeError when attempting to get a value for field `assessment_item_ids` on serializer `AssessmentMetaDataSerializer`.
The serializer field might be named incorrectly and not match any attribute or key on the `RelatedManager` instance.
Original exception text was: 'RelatedManager' object has no attribute 'assessment_item_ids'.
```
* Thanks to @aronasorman. 
