### PR TITLE
max-width

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -27,42 +27,36 @@
             @input="showTitleError = false"
           />
         </KGridItem>
-        <KGridItem sizes="100, 100, 50" percentage>
-          <KGrid>
-            <KGridItem sizes="100, 100, 75" percentage>
-              <KTextbox
-                ref="numQuest"
-                v-model.trim.number="numQuestions"
-                type="number"
-                :min="1"
-                :max="maxQs"
-                :label="moreStrings.$tr('numQuestions')"
-                :invalid="Boolean(showError && numQuestIsInvalidText)"
-                :invalidText="numQuestIsInvalidText"
-                class="number-field"
-              />
-            </KGridItem>
-            <KGridItem sizes="100, 100, 25" percentage>
-              <UiIconButton
-                type="flat"
-                aria-hidden="true"
-                class="number-btn"
-                :disabled="numQuestions === 1"
-                @click="numQuestions -= 1"
-              >
-                <mat-svg name="remove" category="content" />
-              </UiIconButton>
-              <UiIconButton
-                type="flat"
-                aria-hidden="true"
-                class="number-btn"
-                :disabled="numQuestions === maxQs"
-                @click="numQuestions += 1"
-              >
-                <mat-svg name="add" category="content" />
-              </UiIconButton>
-            </KGridItem>
-          </KGrid>
+        <KGridItem sizes="100, 100, 50" percentage class="number-input-grid-item">
+          <KTextbox
+            ref="numQuest"
+            v-model.trim.number="numQuestions"
+            type="number"
+            :min="1"
+            :max="maxQs"
+            :label="moreStrings.$tr('numQuestions')"
+            :invalid="Boolean(showError && numQuestIsInvalidText)"
+            :invalidText="numQuestIsInvalidText"
+            class="number-field"
+          />
+          <UiIconButton
+            type="flat"
+            aria-hidden="true"
+            class="number-btn"
+            :disabled="numQuestions === 1"
+            @click="numQuestions -= 1"
+          >
+            <mat-svg name="remove" category="content" />
+          </UiIconButton>
+          <UiIconButton
+            type="flat"
+            aria-hidden="true"
+            class="number-btn"
+            :disabled="numQuestions === maxQs"
+            @click="numQuestions += 1"
+          >
+            <mat-svg name="add" category="content" />
+          </UiIconButton>
         </KGridItem>
       </KGrid>
       <div>
@@ -444,7 +438,7 @@
 
   .number-field {
     display: inline-block;
-    width: 100%;
+    max-width: 250px;
     margin-right: 8px;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -37,42 +37,36 @@
           />
         </KGridItem>
         <KGridItem sizes="100, 100, 50" percentage>
-          <KGrid>
-            <KGridItem sizes="100, 100, 75" percentage>
-              <KTextbox
-                ref="questionsInput"
-                v-model.trim.number="numQuestions"
-                type="number"
-                :min="1"
-                :max="maxQs"
-                :invalid="Boolean(showError && numQuestIsInvalidText)"
-                :invalidText="numQuestIsInvalidText"
-                :label="$tr('numQuestions')"
-                class="number-field"
-                @blur="numQuestionsBlurred = true"
-              />
-            </KGridItem>
-            <KGridItem sizes="100, 100, 25" percentage>
-              <UiIconButton
-                type="flat"
-                aria-hidden="true"
-                class="number-btn"
-                :disabled="numQuestions === 1"
-                @click="numQuestions -= 1"
-              >
-                <mat-svg name="remove" category="content" />
-              </UiIconButton>
-              <UiIconButton
-                type="flat"
-                aria-hidden="true"
-                class="number-btn"
-                :disabled="numQuestions === maxQs"
-                @click="numQuestions += 1"
-              >
-                <mat-svg name="add" category="content" />
-              </UiIconButton>
-            </KGridItem>
-          </KGrid>
+          <KTextbox
+            ref="questionsInput"
+            v-model.trim.number="numQuestions"
+            type="number"
+            :min="1"
+            :max="maxQs"
+            :invalid="Boolean(showError && numQuestIsInvalidText)"
+            :invalidText="numQuestIsInvalidText"
+            :label="$tr('numQuestions')"
+            class="number-field"
+            @blur="numQuestionsBlurred = true"
+          />
+          <UiIconButton
+            type="flat"
+            aria-hidden="true"
+            class="number-btn"
+            :disabled="numQuestions === 1"
+            @click="numQuestions -= 1"
+          >
+            <mat-svg name="remove" category="content" />
+          </UiIconButton>
+          <UiIconButton
+            type="flat"
+            aria-hidden="true"
+            class="number-btn"
+            :disabled="numQuestions === maxQs"
+            @click="numQuestions += 1"
+          >
+            <mat-svg name="add" category="content" />
+          </UiIconButton>
         </KGridItem>
       </KGrid>
 
@@ -577,7 +571,7 @@
 
   .number-field {
     display: inline-block;
-    width: 100%;
+    max-width: 250px;
     margin-right: 8px;
   }
 


### PR DESCRIPTION

Maybe just set a max-width? The error message seems like an edge case, and we really shouldn't be trying to shove that much text in there anyway...

typical:

![image](https://user-images.githubusercontent.com/2367265/54855809-02b94a80-4cb5-11e9-9ce0-09b60e5d0bbe.png)

when the error shows up:

![image](https://user-images.githubusercontent.com/2367265/54855800-fa610f80-4cb4-11e9-8de1-a3e425904d8a.png)


cc @jtamiace 



